### PR TITLE
chore: remove link to skip account linking [CAV-1554]

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2236,11 +2236,6 @@
                                       with the same email address. We recommend
                                       you link these accounts.
                                     </p>
-                                    <p class="auth0-lock-alternative">
-                                      <a class="auth0-lock-alternative-link" id="skip" href="#">
-                                        I want to skip this and create a new account. (Not recommended)
-                                      </a>
-                                    </p>
                                   </div>
                                 </div>
                               </div>

--- a/templates/utils/auth0widget.js
+++ b/templates/utils/auth0widget.js
@@ -89,11 +89,6 @@ module.exports = (dynamicSettings, identities, locale = 'en') =>
                                                 <p id="message">
                                                     ${t('introduction')} ${t('identities').replace(identitiesRegex, identities)}.
                                                 </p>
-                                                <p class="auth0-lock-alternative">
-                                                    <a class="auth0-lock-alternative-link" id="skip" href="#">
-                                                    ${t('skipAlternativeLink')}
-                                                    </a>
-                                                </p>
                                                 </div>
                                             </div>
                                             </div>


### PR DESCRIPTION
[CAV-1554](https://cavallo.atlassian.net/browse/CAV-1554) Django Admin to utilize Auth0 - sign in, sign out, and create user(s)
## Why
The backend management application for companies and users currently uses its own authentication system, built into Django. We need to strip most of the functionality out of the in-built system and redirect the authentication to Auth0.
## How
* Remove link to skip account linking when signing in with Auth0

Verified - Check those that apply
~[] Tests added for Bugs or Functionality~
~[] Swagger documentation updated for New or updated Endpoints~
~[] Documentation updated in docs folder~
~[] Backwards compatibility considered/documented/coded against~

[CAV-1554]: https://cavallo.atlassian.net/browse/CAV-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ